### PR TITLE
Persist filter options on refresh

### DIFF
--- a/src/components/common/useLocalStorageState.ts
+++ b/src/components/common/useLocalStorageState.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
+
+const useLocalStorageState = <T>(key: string, initialValue: T): [T, Dispatch<SetStateAction<T>>] => {
+  const [state, setState] = useState<T>(() => {
+    const localStorageValue = localStorage.getItem(key);
+    return localStorageValue ? JSON.parse(localStorageValue) : initialValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [key, state]);
+
+  return [state, setState];
+};
+
+export default useLocalStorageState;

--- a/src/components/filter/FilterBar.tsx
+++ b/src/components/filter/FilterBar.tsx
@@ -65,11 +65,13 @@ interface FilterBarProps {
   setBookA: React.Dispatch<React.SetStateAction<BookOption[]>>;
   bookB: BookOption[];
   setBookB: React.Dispatch<React.SetStateAction<BookOption[]>>;
+  showLive: boolean,
   setShowLive: React.Dispatch<React.SetStateAction<boolean>>;
+  showPush: boolean,
   setShowPush: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function FilterBar({ betOption, setBetOption, bookA, setBookA, bookB, setBookB, setShowLive, setShowPush }: FilterBarProps) {
+export default function FilterBar({ betOption, setBetOption, bookA, setBookA, bookB, setBookB, showLive, setShowLive, showPush, setShowPush }: FilterBarProps) {
   const onChange = (option: BetOption | null, _actionMeta: ActionMeta<BetOption>) => {
     if (option !== null) {
       setBetOption(option);
@@ -130,6 +132,7 @@ export default function FilterBar({ betOption, setBetOption, bookA, setBookA, bo
                   className="switch-element"
                   control={
                     <BlueSwitch
+                      checked={showLive}
                       onChange={(event) => {
                         setShowLive(event.target.checked);
                       }}
@@ -152,6 +155,7 @@ export default function FilterBar({ betOption, setBetOption, bookA, setBookA, bo
                   className="switch-element-"
                   control={
                     <BlueSwitch
+                      checked={showPush}
                       onChange={(event) => {
                         setShowPush(event.target.checked);
                       }}

--- a/src/components/layout/App.tsx
+++ b/src/components/layout/App.tsx
@@ -9,6 +9,7 @@ import axios from "axios";
 import "typeface-roboto";
 import "typeface-roboto-mono";
 import { Option } from "../../enums"
+import useLocalStorageState from "../common/useLocalStorageState";
 
 function readyBookList(book: Option[]) {
   let arr = book.map((ob) => ob.value);
@@ -20,11 +21,11 @@ function readyBookList(book: Option[]) {
 }
 
 function App() {
-  const [betOption, setBetOption] = useState(bet_type_options[1]);
-  const [bookA, setBookA] = useState(book_options_all);
-  const [bookB, setBookB] = useState(book_options_all);
-  const [showLive, setShowLive] = useState(false);
-  const [showPush, setShowPush] = useState(false);
+  const [betOption, setBetOption] = useLocalStorageState('betOption', bet_type_options[1]);
+  const [bookA, setBookA] = useLocalStorageState('bookA', book_options_all);
+  const [bookB, setBookB] = useLocalStorageState('bookB', book_options_all);
+  const [showLive, setShowLive] = useLocalStorageState('showLive', false);
+  const [showPush, setShowPush] = useLocalStorageState('showPush', false);
   const [data, setData] = useState([]);
 
   useEffect(() => {
@@ -50,7 +51,9 @@ function App() {
           setBookA={setBookA}
           bookB={bookB}
           setBookB={setBookB}
+          showLive={showLive}
           setShowLive={setShowLive}
+          showPush={showPush}
           setShowPush={setShowPush}
         />
         {!bookA.length || !bookB.length ? (


### PR DESCRIPTION
Save the bet option, book a, book b, show live, and show push in local storage so that they persist upon refresh.